### PR TITLE
Limit the pan gesture to a single finger touch. Fixes #562

### DIFF
--- a/App Delegate/MITSlidingViewController.m
+++ b/App Delegate/MITSlidingViewController.m
@@ -143,6 +143,7 @@ static CGFloat const MITSlidingViewControllerDefaultAnchorRightPeekAmountPhone =
     if ([segue.identifier isEqualToString:MITSlidingViewControllerTopSegueIdentifier]) {
         UIViewController *topViewController = segue.destinationViewController;
 
+        self.panGesture.maximumNumberOfTouches = 1;
         [topViewController.view addGestureRecognizer:self.panGesture];
 
         topViewController.view.layer.shadowOpacity = 1.0;


### PR DESCRIPTION
This prevents the pan gesture from overriding the two-finger swipe for showing the server picker.