### PR TITLE
Fixes: Out of bounds exception causing News to crash on initial start. Fixes #686 References #685

### DIFF
--- a/Modules/News/View Controllers/MITNewsViewController.m
+++ b/Modules/News/View Controllers/MITNewsViewController.m
@@ -860,7 +860,12 @@ CGFloat const refreshControlTextHeight = 19;
     if (self.showSearchStories) {
         return self.searchDataSource;
     } else {
-        return self.dataSources[section];
+        
+        if ([self.dataSources count] <= section) {
+            return nil;
+        } else {
+            return self.dataSources[section];
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: Out of bounds exception causing News to crash on initial start. 
Fixes #686 References #685