### PR TITLE
Shuttles - iPad All Routes deselecting annotation zooms out #681

### DIFF
--- a/Modules/ShuttleTrack/MITShuttleMapViewController.m
+++ b/Modules/ShuttleTrack/MITShuttleMapViewController.m
@@ -531,8 +531,6 @@ typedef NS_OPTIONS(NSUInteger, MITShuttleStopState) {
         
         [self.view layoutIfNeeded]; // ensure that map has autoresized before setting region
         [self.tiledMapView.mapView setRegion:region animated:NO]; // Animated to NO to prevent map kit issue where animating the map causes the bounding box to be zoomed out to far sometimes.
-    } else {
-        [self centerToShuttleStop:self.stop animated:animated];
     }
 }
 

--- a/Modules/ShuttleTrack/MITShuttleRootViewController.m
+++ b/Modules/ShuttleTrack/MITShuttleRootViewController.m
@@ -1,4 +1,4 @@
- #import "MITShuttleRootViewController.h"
+#import "MITShuttleRootViewController.h"
 #import "MITShuttleHomeViewController.h"
 #import "MITShuttleRouteViewController.h"
 #import "MITShuttleMapViewController.h"
@@ -156,7 +156,7 @@
 {
     if (self.mapViewController.isViewLoaded) {
         [self.mapViewController setRoute:route stop:stop];
-        self.mapViewController.shouldUsePinAnnotations = (route || stop);
+        self.mapViewController.shouldUsePinAnnotations = (route != nil);
     }
 }
 

--- a/Modules/ShuttleTrack/MITShuttleRootViewController.m
+++ b/Modules/ShuttleTrack/MITShuttleRootViewController.m
@@ -226,7 +226,6 @@
     UIViewController *masterViewController = self.masterViewController;
     if (masterViewController == self.homeViewController) {
         [self.homeViewController highlightStop:nil];
-        [self setMapViewControllerRoute:nil stop:nil];
     } else if (masterViewController == self.routeViewController) {
         [self.routeViewController highlightStop:nil];
     }


### PR DESCRIPTION
When On All Routes Page and zooming into the map, deselecting an annotation should NOT zoom the map all the way out.