### PR TITLE
Correct Shuttles route status logic.

### DIFF
--- a/Modules/ShuttleTrack/MITShuttleMapViewController.m
+++ b/Modules/ShuttleTrack/MITShuttleMapViewController.m
@@ -805,7 +805,7 @@ typedef NS_OPTIONS(NSUInteger, MITShuttleStopState) {
             calloutSubtitle = [NSString stringWithFormat:@"Arriving %@", arrivalTime];
             break;
         }
-        case MITShuttleRouteStatusPredictionsUnavailable: {
+        case MITShuttleRouteStatusUnknown: {
             calloutSubtitle = @"No current predictions";
             break;
         }

--- a/Modules/ShuttleTrack/MITShuttleRouteCell.m
+++ b/Modules/ShuttleTrack/MITShuttleRouteCell.m
@@ -47,7 +47,7 @@ static const UILayoutPriority kAlertContainerViewHeightConstraintPriorityHidden 
         case MITShuttleRouteStatusInService:
             self.statusIconImageView.image = [UIImage imageNamed:MITImageShuttlesInService];
             break;
-        case MITShuttleRouteStatusPredictionsUnavailable:
+        case MITShuttleRouteStatusUnknown:
             self.statusIconImageView.image = [UIImage imageNamed:MITImageShuttlesUnknown];
             break;
         default:

--- a/Modules/ShuttleTrack/MITShuttleRouteStatusCell.m
+++ b/Modules/ShuttleTrack/MITShuttleRouteStatusCell.m
@@ -28,7 +28,7 @@
             self.statusLabel.text = @"In service";
             self.statusIconImageView.image = [UIImage imageNamed:MITImageShuttlesInServiceSmall];
             break;
-        case MITShuttleRouteStatusPredictionsUnavailable:
+        case MITShuttleRouteStatusUnknown:
             self.statusLabel.text = @"No current predictions";
             self.statusIconImageView.image = [UIImage imageNamed:MITImageShuttlesUnknownSmall];
             break;

--- a/Modules/ShuttleTrack/MITShuttleRouteViewController.m
+++ b/Modules/ShuttleTrack/MITShuttleRouteViewController.m
@@ -285,7 +285,7 @@ static NSString * const kMITShuttleRouteStatusCellNibName = @"MITShuttleRouteSta
         NSInteger stopIndex = indexPath.row - [self headerCellCount];
         MITShuttleStop *stop = self.route.stops[stopIndex];
         MITShuttleRouteStatus routeStatus = self.route.status;
-        if (routeStatus != MITShuttleRouteStatusPredictionsUnavailable) {
+        if (routeStatus != MITShuttleRouteStatusUnknown) {
             MITShuttlePrediction *prediction = [stop nextPrediction];
             [cell setStop:stop prediction:prediction];
             [cell setIsNextStop:(routeStatus == MITShuttleRouteStatusInService && [self.route isNextStop:stop])];

--- a/Modules/ShuttleTrack/Models/Entities/MITShuttleRoute.h
+++ b/Modules/ShuttleTrack/Models/Entities/MITShuttleRoute.h
@@ -8,7 +8,7 @@
 typedef NS_ENUM(NSUInteger, MITShuttleRouteStatus) {
     MITShuttleRouteStatusNotInService = 0,
     MITShuttleRouteStatusInService,
-    MITShuttleRouteStatusPredictionsUnavailable
+    MITShuttleRouteStatusUnknown
 };
 
 @interface MITShuttleRoute : MITManagedObject <MITMappedObject>

--- a/Modules/ShuttleTrack/Models/Entities/MITShuttleRoute.m
+++ b/Modules/ShuttleTrack/Models/Entities/MITShuttleRoute.m
@@ -86,11 +86,16 @@
 
 - (MITShuttleRouteStatus)status
 {
-    if ([self.scheduled boolValue]) {
-        return self.predictable ? MITShuttleRouteStatusInService : MITShuttleRouteStatusPredictionsUnavailable;
-    } else {
-        return MITShuttleRouteStatusNotInService;
+    // `predictable == true` trumps all. If the route has predictable vehicles, consider it in service regardless of the `scheduled` flag.
+    if ([self.predictable boolValue]) {
+        return MITShuttleRouteStatusInService;
     }
+    // `scheduled` but not `predictable` means it should be running but it's not, which is the unknown status.
+    if ([self.scheduled boolValue]) {
+        return MITShuttleRouteStatusUnknown;
+    }
+    // If not `predictable` or `scheduled` then it's not in service, as expected.
+    return MITShuttleRouteStatusNotInService;
 }
 
 - (BOOL)isNextStop:(MITShuttleStop *)stop


### PR DESCRIPTION
Routes with vehicles should always be shown as running, regardless of whether they're scheduled.