### PR TITLE
iPhone - Stop View - Disable arrival time cell when alarm cannot be set #696

### DIFF
--- a/Modules/ShuttleTrack/MITShuttleStopAlarmCell.h
+++ b/Modules/ShuttleTrack/MITShuttleStopAlarmCell.h
@@ -7,6 +7,7 @@
 @interface MITShuttleStopAlarmCell : UITableViewCell
 
 @property (nonatomic, weak) id <MITShuttleStopAlarmCellDelegate> delegate;
+@property (nonatomic, weak) IBOutlet UIButton *alertButton;
 
 - (void)updateUIWithPrediction:(MITShuttlePrediction *)prediction;
 - (void)updateNotificationButtonWithPrediction:(MITShuttlePrediction *)prediction;

--- a/Modules/ShuttleTrack/MITShuttleStopAlarmCell.m
+++ b/Modules/ShuttleTrack/MITShuttleStopAlarmCell.m
@@ -6,7 +6,6 @@
 @interface MITShuttleStopAlarmCell ()
 
 @property (nonatomic, weak) IBOutlet UILabel *timeRemainingLabel;
-@property (nonatomic, weak) IBOutlet UIButton *alertButton;
 
 - (IBAction)notificationButtonPressed:(id)sender;
 

--- a/Modules/ShuttleTrack/MITShuttleStopViewController.m
+++ b/Modules/ShuttleTrack/MITShuttleStopViewController.m
@@ -370,8 +370,9 @@ typedef NS_ENUM(NSUInteger, MITShuttleStopViewControllerSectionType) {
         }
     } else if (sectionType == MITShuttleStopViewControllerSectionTypePredictions) {
         MITShuttleStopAlarmCell *alarmCell = (MITShuttleStopAlarmCell *)[tableView cellForRowAtIndexPath:indexPath];
-        [self stopAlarmCellDidToggleAlarm:alarmCell];
-        
+        if (!alarmCell.alertButton.hidden) {
+            [self stopAlarmCellDidToggleAlarm:alarmCell];
+        }
     }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }


### PR DESCRIPTION
iPhone - Stop View - Disable arrival time cell when alarm cannot be set #696

This action is not needed because we already wee the arrival times on the tableview.