### PR TITLE
Hiding last cell separator on People Details View Using Table View Footer #719.

### DIFF
--- a/Modules/People/PeopleDetailsViewController.m
+++ b/Modules/People/PeopleDetailsViewController.m
@@ -44,8 +44,16 @@ static NSString * AttributeCellReuseIdentifier = @"AttributeCell";
     [self adjustTableViewInsets];
     
     [self updateTableViewHeaderView];
-	   
-    self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    if (!self.tableView.tableFooterView) {
+        UIView *tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 1)];
+        tableFooterView.backgroundColor = [UIColor clearColor];
+        self.tableView.tableFooterView = tableFooterView;
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -250,18 +258,6 @@ static NSString * AttributeCellReuseIdentifier = @"AttributeCell";
             else
             {
                 cell.textLabel.text = @"Add to Favorites";
-            }
-            
-            if( [cell respondsToSelector:@selector(setSeparatorInset:)] )
-            {
-                cell.separatorInset = UIEdgeInsetsMake(0.f, 0.f, 0.f, self.view.frame.size.height);
-                if ([cell respondsToSelector:@selector(setPreservesSuperviewLayoutMargins:)]) {
-                    [cell setPreservesSuperviewLayoutMargins:NO];
-                }
-                
-                if ([cell respondsToSelector:@selector(setLayoutMargins:)]) {
-                    [cell setLayoutMargins:UIEdgeInsetsZero];
-                }
             }
         }
 		


### PR DESCRIPTION
When using the previous way the cell's text would shift left too.  This completely hides the cell separator and doesn't modify the cell's separator insets.