### PR TITLE
Need to disable scrollsToTop on other scroll views to get tours stop detail to scroll to top. #730

### DIFF
--- a/Modules/Tours/MITToursStopDetailViewController.m
+++ b/Modules/Tours/MITToursStopDetailViewController.m
@@ -103,6 +103,10 @@
     
     self.nearHereCollectionView.dataSource = self.nearHereCollectionViewManager;
     self.nearHereCollectionView.delegate = self.nearHereCollectionViewManager;
+    
+    self.mainLoopCollectionView.scrollsToTop = NO;
+    self.nearHereCollectionView.scrollsToTop = NO;
+
 }
 
 - (void)setCollectionViewScrollInsets


### PR DESCRIPTION
Multiple scroll views are present.  Need to disable scrollsToTop on other scroll views to get tours stop detail to scroll to top. Fixes #730