### PR TITLE
Orphaned stops are now deleted when grabbing all routes.

### DIFF
--- a/Common/Core Data/MITMobile.m
+++ b/Common/Core Data/MITMobile.m
@@ -237,9 +237,10 @@ NSString* const MITMobileErrorDomain = @"MITMobileErrorDomain";
                 // Setup the fetch request generators so we can have nice things like orphaned object
                 // deletion.
                 __weak MITMobileManagedResource *weakResource = managedResource;
-                [objectManager addFetchRequestBlock:^(NSURL *URL) {
-                    return [weakResource fetchRequestForURL:URL];
-                }];
+                for (NSFetchRequest *(^fetchRequestBlock)(NSURL *URL) in [weakResource fetchRequestForURLBlocks]) {
+                    [objectManager addFetchRequestBlock:fetchRequestBlock];
+                }
+                
             }
         }];
         

--- a/Common/Core Data/MITMobileManagedResource.h
+++ b/Common/Core Data/MITMobileManagedResource.h
@@ -16,5 +16,6 @@ typedef void (^MITMobileManagedResult)(NSFetchRequest *fetchRequest, NSDate *las
 
 - (instancetype)initWithName:(NSString *)name pathPattern:(NSString *)pathPattern managedObjectModel:(NSManagedObjectModel*)managedObjectModel;
 - (NSFetchRequest*)fetchRequestForURL:(NSURL *)url;
+- (NSArray*)fetchRequestForURLBlocks;
 
 @end

--- a/Common/Core Data/MITMobileManagedResource.m
+++ b/Common/Core Data/MITMobileManagedResource.m
@@ -31,4 +31,14 @@
 {
     return nil;
 }
+
+- (NSArray*)fetchRequestForURLBlocks
+{
+    // If not overridden, assume there is only one fetch request and return that in a block in an array
+    NSFetchRequest *(^fetchRequestBlock)(NSURL *URL) = ^NSFetchRequest *(NSURL *URL) {
+        return [self fetchRequestForURL:URL];
+    };
+    return @[fetchRequestBlock];
+}
+
 @end

--- a/Common/Core Data/MITShuttlesResource.m
+++ b/Common/Core Data/MITShuttlesResource.m
@@ -22,19 +22,39 @@
     return self;
 }
 
-- (NSFetchRequest *)fetchRequestForURL:(NSURL *)url
+- (NSArray *)fetchRequestForURLBlocks
 {
-    RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPath:[[url relativePath] stringByAppendingString:@"/"]];
+    NSFetchRequest *(^fetchRequestForRouteBlock)(NSURL *URL) = ^NSFetchRequest *(NSURL *URL) {
+        RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPath:[[URL relativePath] stringByAppendingString:@"/"]];
+        
+        NSDictionary *parameters = nil;
+        BOOL matches = [pathMatcher matchesPattern:self.pathPattern tokenizeQueryStrings:YES parsedArguments:&parameters];
+        
+        if (matches) {
+            NSFetchRequest *fetchRequestForRoute = [NSFetchRequest fetchRequestWithEntityName:[MITShuttleRoute entityName]];
+            fetchRequestForRoute.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"identifier" ascending:YES]];
+            return fetchRequestForRoute;
+        }
+        
+        return nil;
+    };
     
-    NSDictionary *parameters = nil;
-    BOOL matches = [pathMatcher matchesPattern:self.pathPattern tokenizeQueryStrings:YES parsedArguments:&parameters];
+    NSFetchRequest *(^fetchRequestForChildStopsBlock)(NSURL *URL) = ^NSFetchRequest *(NSURL *URL) {
+        RKPathMatcher *pathMatcher = [RKPathMatcher pathMatcherWithPath:[[URL relativePath] stringByAppendingString:@"/"]];
+        
+        NSDictionary *parameters = nil;
+        BOOL matches = [pathMatcher matchesPattern:self.pathPattern tokenizeQueryStrings:YES parsedArguments:&parameters];
+        
+        if (matches) {
+            NSFetchRequest *fetchRequestForChildStops = [NSFetchRequest fetchRequestWithEntityName:[MITShuttleStop entityName]];
+            fetchRequestForChildStops.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"identifier" ascending:YES]];
+            return fetchRequestForChildStops;
+        }
+        
+        return nil;
+    };
     
-    if (matches) {
-        NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:[MITShuttleRoute entityName]];
-        fetchRequest.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"identifier" ascending:YES]];
-        return fetchRequest;
-    }
-    return nil;
+    return @[fetchRequestForRouteBlock, fetchRequestForChildStopsBlock];
 }
 
 @end


### PR DESCRIPTION
Fix for orphaned stop crash as noted in #425 comment https://github.com/MIT-Mobile/MIT-Mobile-for-iPhone/issues/425#issuecomment-69988685