### PR TITLE
Use placeholder text for non-decodable QR codes.

### DIFF
--- a/Modules/QR Reader/MITScannerMgr.m
+++ b/Modules/QR Reader/MITScannerMgr.m
@@ -249,7 +249,11 @@ NSString * const kBatchScanningSettingKey = @"kBatchScanningSettingKey";
                    forBarCode:(AVMetadataMachineReadableCodeObject *)code
                    completion:(void (^)(void))completionBlock
 {
-    [self.scannerHistory insertScanResult:code.stringValue
+    NSString *decodedString = code.stringValue;
+    if (!decodedString) {
+        decodedString = @"Unable to decode";
+    }
+    [self.scannerHistory insertScanResult:decodedString
                                  withDate:[NSDate date]
                                 withImage:image
                   shouldGenerateThumbnail:YES


### PR DESCRIPTION
Prevent a crash when scanning the QR codes from Japanese visas. They aren't decodable by Apple's scanner library, and the app was crashing when trying to read them.

Resolves #762.