### PR TITLE
4.0/mark changes

### DIFF
--- a/Modules/Dining/MITDiningScheduleCell.m
+++ b/Modules/Dining/MITDiningScheduleCell.m
@@ -40,9 +40,13 @@ static CGFloat const kMITDiningScheduleCellEstimatedHeight = 67.0;
 - (void)setMealSummary:(MITDiningMealSummary *)mealSummary
 {
     self.dateRangesLabel.text = mealSummary.dateRangesString;
-    self.mealNamesLabel.text = mealSummary.mealNamesStringsOnSeparateLines;
-    self.mealTimesLabel.text = mealSummary.mealTimesStringsOnSeparateLines;
-    
+    if (![mealSummary.meals count]) {
+        self.mealNamesLabel.text = @"Closed";
+        self.mealTimesLabel.text = @"";
+    } else {
+        self.mealNamesLabel.text = mealSummary.mealNamesStringsOnSeparateLines;
+        self.mealTimesLabel.text = mealSummary.mealTimesStringsOnSeparateLines;
+    }
     [self layoutIfNeeded];
 }
 

--- a/Modules/Emergency/EmergencyViewController.m
+++ b/Modules/Emergency/EmergencyViewController.m
@@ -79,11 +79,9 @@ typedef NS_ENUM(NSUInteger, MITEmergencyTableSection) {
 
 - (void)setHtmlString:(NSString *)htmlString
 {
-    if (![_htmlString isEqualToString:htmlString]) {
-        _htmlString = [htmlString copy];
-        [self.infoWebView loadHTMLString:self.htmlString
-                                 baseURL:nil];
-    }
+    _htmlString = [htmlString copy];
+    [self.infoWebView loadHTMLString:self.htmlString
+                             baseURL:nil];
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {

--- a/Modules/ShuttleTrack/MITShuttleHomeViewController.m
+++ b/Modules/ShuttleTrack/MITShuttleHomeViewController.m
@@ -39,7 +39,6 @@ typedef NS_ENUM(NSUInteger, MITShuttleSection) {
 
 @interface MITShuttleHomeViewController ()
 
-@property (weak, nonatomic) IBOutlet UIView *toolbarLabelView;
 @property (weak, nonatomic) IBOutlet UILabel *lastUpdatedLabel;
 @property (weak, nonatomic) IBOutlet UILabel *locationStatusLabel;
 
@@ -96,7 +95,6 @@ typedef NS_ENUM(NSUInteger, MITShuttleSection) {
     self.routesDataSource = [[MITShuttleRoutesDataSource alloc] init];
     
     [self setupTableView];
-    [self setupToolbar];
     [self setupResourceData];
     
     self.tableView.rowHeight = 44.0;
@@ -105,12 +103,6 @@ typedef NS_ENUM(NSUInteger, MITShuttleSection) {
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
-    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
-        [self.navigationController setToolbarHidden:YES animated:animated];
-    } else {
-        [self.navigationController setToolbarHidden:NO animated:animated];
-    }
     
     [self startRefreshingRoutesAndPredictions];
     
@@ -177,12 +169,6 @@ typedef NS_ENUM(NSUInteger, MITShuttleSection) {
     UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
     [refreshControl addTarget:self action:@selector(refreshControlActivated:) forControlEvents:UIControlEventValueChanged];
     self.refreshControl = refreshControl;
-}
-
-- (void)setupToolbar
-{
-    UIBarButtonItem *toolbarLabelItem = [[UIBarButtonItem alloc] initWithCustomView:self.toolbarLabelView];
-    [self setToolbarItems:@[[UIBarButtonItem flexibleSpace], toolbarLabelItem, [UIBarButtonItem flexibleSpace]]];
 }
 
 - (void)setupResourceData

--- a/Modules/ShuttleTrack/MITShuttleHomeViewController.xib
+++ b/Modules/ShuttleTrack/MITShuttleHomeViewController.xib
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MITShuttleHomeViewController">
             <connections>
-                <outlet property="lastUpdatedLabel" destination="7Zf-u1-L5b" id="k79-Gn-A3w"/>
-                <outlet property="locationStatusLabel" destination="ZgS-b9-RkS" id="5eU-BK-yge"/>
-                <outlet property="toolbarLabelView" destination="Mzf-lF-E5Z" id="8uB-Z0-jnf"/>
                 <outlet property="view" destination="fz8-rU-T6F" id="Z2a-h0-vDU"/>
             </connections>
         </placeholder>
@@ -25,33 +22,6 @@
                 <outlet property="delegate" destination="-1" id="SuV-LQ-exI"/>
             </connections>
         </tableView>
-        <view contentMode="scaleToFill" id="Mzf-lF-E5Z">
-            <rect key="frame" x="0.0" y="0.0" width="288" height="30"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated 1 minute ago" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Zf-u1-L5b">
-                    <rect key="frame" x="82" y="0.0" width="125" height="15"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Showing nearest stops" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZgS-b9-RkS">
-                    <rect key="frame" x="80" y="15" width="128" height="15"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <color key="textColor" white="0.30090725810000002" alpha="1" colorSpace="calibratedWhite"/>
-                    <nil key="highlightedColor"/>
-                </label>
-            </subviews>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-            <constraints>
-                <constraint firstAttribute="bottom" secondItem="ZgS-b9-RkS" secondAttribute="bottom" id="4s4-M1-qxm"/>
-                <constraint firstAttribute="centerX" secondItem="ZgS-b9-RkS" secondAttribute="centerX" id="79h-XX-2fB"/>
-                <constraint firstItem="7Zf-u1-L5b" firstAttribute="top" secondItem="Mzf-lF-E5Z" secondAttribute="top" id="Kap-bY-AoK"/>
-                <constraint firstAttribute="centerX" secondItem="7Zf-u1-L5b" secondAttribute="centerX" id="S8X-gW-9DV"/>
-            </constraints>
-            <nil key="simulatedStatusBarMetrics"/>
-            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-        </view>
     </objects>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>


### PR DESCRIPTION
Fix: Dining house detail view shows a blank for hours Closes. #756.	
When setting the html string we always want to reload the webview. Closes #764.	
Remove status toolbar from iPad Shuttles. Closes #759